### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Venti.php
+++ b/src/Venti.php
@@ -79,7 +79,7 @@ class Venti extends Plugin
         );
 		
         // Add in our Twig extensions
-        Craft::$app->view->twig->addExtension(new VentiTwigExtension());
+        Craft::$app->view->registerTwigExtension(new VentiTwigExtension());
 
 		$this->setComponents([
             'groups' => \tippingmedia\venti\services\Groups::class,


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.